### PR TITLE
Add scraped page archive

### DIFF
--- a/scraper.rb
+++ b/scraper.rb
@@ -6,9 +6,10 @@ require 'scraperwiki'
 require 'nokogiri'
 require 'open-uri'
 
-require 'pry'
-require 'open-uri/cached'
-OpenURI::Cache.cache_path = '.cache'
+# require 'pry'
+# require 'open-uri/cached'
+# OpenURI::Cache.cache_path = '.cache'
+require 'scraped_page_archive/open-uri'
 
 class String
   def tidy


### PR DESCRIPTION
## What does this do?

Uses scraped-page-archive to archive all pages scraped.

## Why is this needed?

The country has had a recent election (2016-06-06).  I hoped that we might be able to archive the previous term before it disappears but it looks like the site now lists the current term. As I had already begun to add the scraper, archiving the current term was only a trivial step -- at least it's now archived for the future.

## Relevant Issue(s):

https://github.com/everypolitician/everypolitician-data/issues/20544

## Checklists:

### Scraper change:
* [x] scraper is on Morph.io under the "everypolitician-scrapers" group.
* [x] scraper's GitHub "Website" link points at morph.io page 
* [x] scraper is set to auto-run.
* [x] scraper is configured for archiving

### Adding Archiving:
* [x] scraper uses scraped-page-archive gem directly or via a suitable strategy — uses it directly
* [x] MORPH_SCRAPER_CACHE_GITHUB_REPO_URL is configured
* [x] pages are being archived in new branch of correct scraper repo (yay!)
